### PR TITLE
Fix button default variants

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -8,11 +8,11 @@ import { cn } from '@/lib/utils';
 const buttonVariants = cva(
   'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
     variants: {
-      defaultVariants: {
-        size: 'default',
-        variant: 'default',
-      },
       size: {
         default: 'h-10 px-4 py-2',
         icon: 'h-10 w-10',


### PR DESCRIPTION
## Summary
- use `defaultVariants` at the top-level of the `cva` config for `Button`

## Testing
- `npm run lint`
- `npm run build` *(fails: A Cloudinary Cloud name is required)*

------
https://chatgpt.com/codex/tasks/task_e_685afcc51c848329990f8a9871958c07