### PR TITLE
Fix calc spacing in timeline component

### DIFF
--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -85,7 +85,7 @@ const TimelineEvent: React.FC<TimelineEventProps> = ({ event, isEven }) => {
         ref={ref}
         initial='hidden'
         animate={controls}
-        className='w-[calc(100%-2rem)] md:w-[calc(50%-2.5rem)]'
+        className='w-[calc(100% - 2rem)] md:w-[calc(50% - 2.5rem)]'
         variants={{
           hidden: { opacity: 0, x: isEven ? 50 : -50 },
           visible: {


### PR DESCRIPTION
## Summary
- correct spacing in CSS `calc` expressions for `timeline`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685aff2c4fcc8329af71badb9280b10d