### PR TITLE
Fix button CVA defaults

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -8,11 +8,11 @@ import { cn } from '@/lib/utils';
 const buttonVariants = cva(
   'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
     variants: {
-      defaultVariants: {
-        size: 'default',
-        variant: 'default',
-      },
       size: {
         default: 'h-10 px-4 py-2',
         icon: 'h-10 w-10',


### PR DESCRIPTION
## Summary
- reorder `cva` options in `button.tsx` so `defaultVariants` are top-level
- keep using these defaults when calling `buttonVariants`

## Testing
- `pnpm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685aff2cf780832983609f3f2324caa6